### PR TITLE
RefactoredFastLookupPatchWithoutGoRoutines

### DIFF
--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -518,6 +518,7 @@ func (ms *peerMessageSender) runInfiniteWriter(ctx context.Context) {
 
 	// Main loop for writing requests and messages and handling write errors
 	for {
+		time.Sleep(SmallReadWriteInterval) // time space between writes (pacing)
 		select {
 		// close go routine when remote peer (ms.p) is stopped, based on signal received from OnDisconnect() function
 		case <-ms.infiniteRwCtx.Done():
@@ -531,7 +532,7 @@ func (ms *peerMessageSender) runInfiniteWriter(ctx context.Context) {
 		case request := <-ms.chanrequest:
 			ms.handleRequestWrite(request)
 		default:
-			time.Sleep(SmallReadWriteInterval) // time space between writes (pacing)
+
 		}
 	}
 
@@ -542,13 +543,13 @@ func (ms *peerMessageSender) runInfiniteReader(ctx context.Context) {
 
 	// Main loop for reading responses and handling delivery via receive channels
 	for {
+		time.Sleep(SmallReadWriteInterval) // time space between reads (pacing)
 		select {
 		// close go routine when remote peer (ms.p) is stopped, based on signal received from OnDisconnect() function
 		case <-ms.infiniteRwCtx.Done():
 			logger.Debugw("lookup patch", "infinite reader", "stopped", "for", ms.p.String())
 			return
 		default:
-			time.Sleep(SmallReadWriteInterval) // time space between reads (pacing)
 			ms.handleRequestRead()
 		}
 


### PR DESCRIPTION
- Refactor the code for better readability
- Launch InfiniteWriter and InfiniteReader in separate goroutines for each peer (instead of making one spawn the other)
- Remove go routines inside InfinitrReader and InfiniteWriter (**number of goroutines = 2*number_discovered_peers**)
- Confirm expected number_of_goroutines with "go tool pprof http://ip:port/debug/pprof/goroutine" under both normal conditions and node churn
- Will be tagged **v0.24.2-hive-1.5.1** (if accepted)