### PR TITLE
avoid nil message pointer and send on closed channel

### DIFF
--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -737,6 +737,9 @@ func (ms *peerMessageSender) handleRequestWrite(metaMessage MessageInfo) {
 				retry = true
 				continue
 
+			} else {
+				// no error
+				break
 			}
 		}
 		if ms.singleMes > streamReuseTries {


### PR DESCRIPTION
- Avoid writing nil proto message object
- Keep chanMessage and Chan Request channel to avoid sending on closed channel
- Enable stream reuse and retry after write error in order to be less aggressive in unresponsive peer detection