### PR TITLE
don't close nil stream

### DIFF
--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -687,8 +687,12 @@ func (ms *peerMessageSender) handleMessageWrite(metaMessage MessageInfo) {
 			}
 		}
 		if ms.singleMes > streamReuseTries {
-			_ = ms.s.Close()
-			ms.s = nil
+			// don't close nil stream,
+			// a new stream will be created in the next iteration by ms.prep()
+			if ms.s != nil {
+				_ = ms.s.Close()
+				ms.s = nil
+			}
 		} else if retry {
 			ms.singleMes++
 		}
@@ -743,8 +747,12 @@ func (ms *peerMessageSender) handleRequestWrite(metaMessage MessageInfo) {
 			}
 		}
 		if ms.singleMes > streamReuseTries {
-			_ = ms.s.Close()
-			ms.s = nil
+			// don't close nil stream,
+			// a new stream will be created in the next iteration by ms.prep()
+			if ms.s != nil {
+				_ = ms.s.Close()
+				ms.s = nil
+			}
 		} else if retry {
 			ms.singleMes++
 		}


### PR DESCRIPTION
- Chek before closing stream when reuse threshold is reached
- Let ms.prep() creates new stream for the next message