### PR TITLE
add debug log for ignoring nil stream

### DIFF
--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -690,7 +690,10 @@ func (ms *peerMessageSender) handleMessageWrite(metaMessage MessageInfo) {
 			// don't close nil stream,
 			// a new stream will be created in the next iteration by ms.prep()
 			if ms.s != nil {
-				_ = ms.s.Close()
+				err = ms.s.Close()
+				if err != nil {
+					logger.Debugw("lookup patch", "infinite writer", "error when closing stream", "to", ms.p.String(), "error", err)
+				}
 				ms.s = nil
 			} else {
 				logger.Debugw("lookup patch", "infinite writer", "ignoring nil stream", "to", ms.p.String())
@@ -752,7 +755,10 @@ func (ms *peerMessageSender) handleRequestWrite(metaMessage MessageInfo) {
 			// don't close nil stream,
 			// a new stream will be created in the next iteration by ms.prep()
 			if ms.s != nil {
-				_ = ms.s.Close()
+				err = ms.s.Close()
+				if err != nil {
+					logger.Debugw("lookup patch", "infinite writer", "error when closing stream", "to", ms.p.String(), "error", err)
+				}
 				ms.s = nil
 			} else {
 				logger.Debugw("lookup patch", "infinite writer", "ignoring nil stream", "to", ms.p.String())

--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -692,6 +692,8 @@ func (ms *peerMessageSender) handleMessageWrite(metaMessage MessageInfo) {
 			if ms.s != nil {
 				_ = ms.s.Close()
 				ms.s = nil
+			} else {
+				logger.Debugw("lookup patch", "infinite writer", "ignoring nil stream", "to", ms.p.String())
 			}
 		} else if retry {
 			ms.singleMes++
@@ -752,6 +754,8 @@ func (ms *peerMessageSender) handleRequestWrite(metaMessage MessageInfo) {
 			if ms.s != nil {
 				_ = ms.s.Close()
 				ms.s = nil
+			} else {
+				logger.Debugw("lookup patch", "infinite writer", "ignoring nil stream", "to", ms.p.String())
 			}
 		} else if retry {
 			ms.singleMes++


### PR DESCRIPTION
- Chek before closing stream when reuse threshold is reached
- Let ms.prep() creates new stream for the next message
- Add debug log in case of nil stream