### PR TITLE
prevent check on nil record

### DIFF
--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -790,7 +790,6 @@ func (ms *peerMessageSender) handleRequestRead() {
 		err = response.Unmarshal(bytes)
 		if err != nil {
 			ms.r.ReleaseMsg(bytes)
-			response = nil
 			return
 		}
 		// Retreive request ID from response
@@ -801,9 +800,6 @@ func (ms *peerMessageSender) handleRequestRead() {
 		if ok, rcvChan := ms.findReceiveChan(requestID); ok {
 			// return response via rcv channel and delete requestID entry
 			ms.ReturnResponseViaChan(requestID, rcvChan, response, err)
-		} else {
-			// release memory
-			response = nil
 		}
 		ms.r.ReleaseMsg(bytes)
 

--- a/pb/protocol_messenger.go
+++ b/pb/protocol_messenger.go
@@ -69,6 +69,13 @@ func (pm *ProtocolMessenger) PutValue(ctx context.Context, p peer.ID, rec *recpb
 		return err
 	}
 
+	// avoid check on nil record
+	// occurs only on super nodes in prod
+	if rpmes.GetRecord() == nil || pmes.GetRecord() == nil {
+		const errStr = "nil record in PUT"
+		logger.Warnw(errStr, "put-message", pmes, "get-message", rpmes)
+		return errors.New(errStr)
+	}
 	if !bytes.Equal(rpmes.GetRecord().Value, pmes.GetRecord().Value) {
 		const errStr = "value not put correctly"
 		logger.Infow(errStr, "put-message", pmes, "get-message", rpmes)


### PR DESCRIPTION
- Avoid check on nil record during record update (occurs only on super nodes so far)
- Remove uncessary code blocks

Fixes:
`[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xcf00cf]

goroutine 551542 [running]:
github.com/libp2p/go-libp2p-kad-dht/pb.(*ProtocolMessenger).PutValue(0xc0036a7120, {0x254bad0, 0xc004f8bd40}, {0xc007c5a720, 0x22}, 0xc004f8af00)
        /home/runner/go/pkg/mod/github.com/!hive!net!code/go-libp2p-kad-dht@v0.24.3-0.20240403204808-10807c27cd2f/pb/protocol_messenger.go:72 +0x14f
github.com/libp2p/go-libp2p-kad-dht.(*IpfsDHT).updatePeerValues.func1({0xc007c5a720, 0x22})
        /home/runner/go/pkg/mod/github.com/!hive!net!code/go-libp2p-kad-dht@v0.24.3-0.20240403204808-10807c27cd2f/routing.go:285 +0x106
created by github.com/libp2p/go-libp2p-kad-dht.(*IpfsDHT).updatePeerValues
        /home/runner/go/pkg/mod/github.com/!hive!net!code/go-libp2p-kad-dht@v0.24.3-0.20240403204808-10807c27cd2f/routing.go:274 +0x265
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xcf00cf]

goroutine 32909 [running]:
github.com/libp2p/go-libp2p-kad-dht/pb.(*ProtocolMessenger).PutValue(0xc000b77410, {0x254bad0, 0xc00bef3b60}, {0xc000e22990, 0x22}, 0xc008d1f320)
        /home/runner/go/pkg/mod/github.com/!hive!net!code/go-libp2p-kad-dht@v0.24.3-0.20240403204808-10807c27cd2f/pb/protocol_messenger.go:72 +0x14f
github.com/libp2p/go-libp2p-kad-dht.(*IpfsDHT).updatePeerValues.func1({0xc000e22990, 0x22})
        /home/runner/go/pkg/mod/github.com/!hive!net!code/go-libp2p-kad-dht@v0.24.3-0.20240403204808-10807c27cd2f/routing.go:285 +0x106
created by github.com/libp2p/go-libp2p-kad-dht.(*IpfsDHT).updatePeerValues
        /home/runner/go/pkg/mod/github.com/!hive!net!code/go-libp2p-kad-dht@v0.24.3-0.20240403204808-10807c27cd2f/routing.go:274 +0x265
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xcf00cf]`